### PR TITLE
Enhance search input: disable autoCorrect, autoCapitalize, and spellCheck

### DIFF
--- a/src/app/components/SearchBox.tsx
+++ b/src/app/components/SearchBox.tsx
@@ -118,6 +118,9 @@ export default function SearchBox({ searchTerm, onSearchChange, contributions }:
           aria-activedescendant={activeOptionId}
           className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-black shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500"
           autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
         />
         <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
           <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />


### PR DESCRIPTION
This PR disables browser autoCorrect, autoCapitalize, and spellCheck for the search input, which improves user experience and privacy by preventing unwanted text modifications and spell-check highlights. This is especially helpful for search bars.
